### PR TITLE
feat(tmux): image cat and copy don't jump

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,4 +1,7 @@
 set-option -g prefix C-a
+set -g allow-passthrough on
+set -ga update-environment TERM
+set -ga update-environment TERM_PROGRAM
 bind-key C-a send-prefix
 
 
@@ -32,6 +35,8 @@ set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-open'
+
+set -g @yank_action 'copy-pipe'
 
 set -g @continuum-save-interval '15'
 set -g @continuum-restore 'on'


### PR DESCRIPTION
Support image preview in tmux by imgcat, and enter 'y' not jump to bottom in tmux vi-mode.